### PR TITLE
1 file inputs aren't treated as globs in windows

### DIFF
--- a/src/greplica/grep.py
+++ b/src/greplica/grep.py
@@ -940,7 +940,7 @@ class Grep:
     def context_name_num_sep(self, context_name_num_sep):
         if not isinstance(context_name_num_sep, str):
             raise TypeError('Invalid type ({}) for context_name_num_sep'.format(type(context_name_num_sep)))
-        self._name_num_sep = context_name_num_sep
+        self._context_name_num_sep = context_name_num_sep
 
     @property
     def context_name_byte_sep(self):
@@ -954,7 +954,7 @@ class Grep:
     def context_name_byte_sep(self, context_name_byte_sep):
         if not isinstance(context_name_byte_sep, str):
             raise TypeError('Invalid type ({}) for context_name_byte_sep'.format(type(context_name_byte_sep)))
-        self._name_byte_sep = context_name_byte_sep
+        self._context_name_byte_sep = context_name_byte_sep
 
     @property
     def color_output_mode(self):

--- a/src/greplica/grep.py
+++ b/src/greplica/grep.py
@@ -1645,7 +1645,7 @@ class Grep:
                                     # Do nothing and exclude anything that follows
                                     dirs[:] = []
                 else:
-                    if self._parse_file(file, data):
+                    if self._parse_file(expanded_file, data):
                         matched_files += [expanded_file.name]
 
         return matched_files


### PR DESCRIPTION
- Expand out files when Windows OS is detected
- Don't parse positional for expression if --file specified
- Allow multiple files to be given to --file
- Corrected bug with name/number name/byte-number separator being set to the context separator